### PR TITLE
Product design tweaks

### DIFF
--- a/assets/theme.scss.liquid
+++ b/assets/theme.scss.liquid
@@ -6093,7 +6093,9 @@ $featured-slider-close-background-color: rgba(0, 0, 0, 0);
 .featured-slider__slide-list {
   position: relative;
   z-index: 5;
-  @include media-query($medium-up) {
+  @include media-query($small) {
+    width: 90%;
+    margin: 0 auto;
   }
 }
 
@@ -6108,7 +6110,9 @@ $featured-slider-close-background-color: rgba(0, 0, 0, 0);
 .featured-slider__slide-content {
   position: relative;
   margin: 0 auto;
-  max-width: 45%;
+  @include media-query($medium-up) {
+    max-width: 45%;
+  }
 }
 
 .featured-slider__slide-image-container {
@@ -6117,14 +6121,6 @@ $featured-slider-close-background-color: rgba(0, 0, 0, 0);
 }
 
 .featured-slider__slide-image {
-  display: block;
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  pointer-events: none;
-
   &.placeholder-svg {
     position: relative;
     max-width: 450px;
@@ -6136,9 +6132,10 @@ $featured-slider-close-background-color: rgba(0, 0, 0, 0);
 
 .featured-slider__slide-title {
   margin: ($gutter * 2) 0 $gutter;
-  font-weight: $font-weight-semi-bold;
+  font-size: 1.5em;
+  font-weight: $font-weight-bold;
   letter-spacing: 1px;
-  text-transform: uppercase;
+  text-transform: capitalize;
 }
 
 

--- a/assets/theme.scss.liquid
+++ b/assets/theme.scss.liquid
@@ -5757,9 +5757,40 @@ shopify-payment-terms {
 
 .product-recommendations {
   padding-top: $gutter-site * 3;
+
+  .grid__item {
+    @include media-query($large-up) {
+      max-width: 25vw;
+    }
+
+    @include media-query($medium) {
+      max-width: 50vw;
+    }
+
+    @include media-query($small) {
+      max-width: 90vw;
+    }
+  }
 }
 
+.product-recommendations__content {
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
+  overflow: scroll;
+}
 
+.product-recommendations__list {
+  display: flex;
+
+  @include media-query($medium) {
+    width: 200%;
+  }
+
+  @include media-query($small) {
+    width: 400%;
+  }
+}
 
 $featured-slider-primary-color: #fff;
 $featured-slider-close-background-color: rgba(0, 0, 0, 0);

--- a/assets/theme.scss.liquid
+++ b/assets/theme.scss.liquid
@@ -3488,7 +3488,7 @@ $slick-opacity-not-active: 0.25;
 .site-header__cart .icon,
 .site-header__search .icon {
   font-size: em(25);
-  padding: $gutter-site / 4;
+  padding: $gutter-site / 2;
 
   @include media-query($medium-up) {
     padding: $gutter-site / 2;
@@ -3521,8 +3521,7 @@ $slick-opacity-not-active: 0.25;
       border-radius: 50%;
 
       @include media-query($small) {
-        top: 14px;
-        right: 0;
+        top: 16px;
       }
     }
   }

--- a/assets/theme.scss.liquid
+++ b/assets/theme.scss.liquid
@@ -6112,6 +6112,11 @@ $featured-slider-close-background-color: rgba(0, 0, 0, 0);
   @include media-query($medium-up) {
     max-width: 45%;
   }
+  @include media-query($small) {
+    display: flex;
+    align-items: center;
+    column-gap: 5%;
+  }
 }
 
 .featured-slider__slide-image-container {

--- a/sections/featured-slider.liquid
+++ b/sections/featured-slider.liquid
@@ -72,23 +72,15 @@
         data-aspectratio="{{ section.settings.cover_banner_image.aspect_ratio }}"
         data-sizes="auto"
         alt="{{ section.settings.cover_banner_image.alt | escape }}">
-      <!-- <div class="pinch-indicators">
-        <div class="pinch-indicator pinch-indicator--top"></div>
-        <div class="pinch-indicator pinch-indicator--bottom"></div>
-      </div> -->
     </div>
-    <!-- <button class="btn btn--clear featured-slider__close reveal-slider__close">
-      <span class="featured-slider__close-icon">{% include 'icon-close' %}</span>
-      <span class="featured-slider__close-circle" style="border-color: {{ section.settings.text_color }}"></span>
-    </button> -->
 
     <div class="featured-slider__slide-list">
       {% for block in section.blocks %}
         <div class="featured-slider__slide side-scroller__slide slider__slide{% if forloop.first %} slider__slide--active {% endif %}" data-background-color="{{ block.settings.background_color }}" {{ block.shopify_attributes }}>
-          <div class="featured-slider__slide-content">
+          <div class="featured-slider__slide-content grid">
             {% if block.settings.show_image %}
               {% if block.settings.slide_image %}
-                <div class="featured-slider__slide-image-container" style="padding-top: {{ 1 | divided_by: block.settings.slide_image.aspect_ratio | times: 100}}%">
+                <div class="featured-slider__slide-image-container grid__item small--one-half">
                   {% assign img_url = block.settings.slide_image | img_url: '1x1' | replace: '_1x1.', '_{width}x.' %}
                   <img class="featured-slider__slide-image lazyload"
                     data-src="{{ img_url }}"
@@ -102,12 +94,16 @@
                 {{ 'product-' | append: forloop.index | placeholder_svg_tag: placeholder_class }}
               {% endif %}
             {% endif %}
-            {% if block.settings.slide_title != blank %}
-              <h3 class="featured-slider__slide-title h6" style="color: {{ section.settings.text_color }}">{{ block.settings.slide_title }}</h3>
-            {% endif %}
-
-            {% if block.settings.slide_button_text != blank %}
-              <a class="btn featured-slider__slide-link{% if section.settings.use_second_button %} btn--secondary{% endif %}" href="{{ block.settings.slide_button_url }}">{{ block.settings.slide_button_text }}</a>
+            {% if block.settings.slide_title != blank or block.settings.slide_button_text != blank%}
+              <div class="grid__item small--one-half">
+                {% if block.settings.slide_title != blank %}
+                  <h3 class="featured-slider__slide-title h6" style="color: {{ section.settings.text_color }}">{{ block.settings.slide_title }}</h3>
+                {% endif %}
+  
+                {% if block.settings.slide_button_text != blank %}
+                  <a class="btn featured-slider__slide-link{% if section.settings.use_second_button %} btn--secondary{% endif %}" href="{{ block.settings.slide_button_url }}">{{ block.settings.slide_button_text }}</a>
+                {% endif %}
+              </div>
             {% endif %}
           </div>
         </div>

--- a/sections/featured-slider.liquid
+++ b/sections/featured-slider.liquid
@@ -77,10 +77,10 @@
     <div class="featured-slider__slide-list">
       {% for block in section.blocks %}
         <div class="featured-slider__slide side-scroller__slide slider__slide{% if forloop.first %} slider__slide--active {% endif %}" data-background-color="{{ block.settings.background_color }}" {{ block.shopify_attributes }}>
-          <div class="featured-slider__slide-content grid">
+          <div class="featured-slider__slide-content">
             {% if block.settings.show_image %}
               {% if block.settings.slide_image %}
-                <div class="featured-slider__slide-image-container grid__item small--one-half">
+                <div class="featured-slider__slide-image-container small--one-half">
                   {% assign img_url = block.settings.slide_image | img_url: '1x1' | replace: '_1x1.', '_{width}x.' %}
                   <img class="featured-slider__slide-image lazyload"
                     data-src="{{ img_url }}"
@@ -95,7 +95,7 @@
               {% endif %}
             {% endif %}
             {% if block.settings.slide_title != blank or block.settings.slide_button_text != blank%}
-              <div class="grid__item small--one-half">
+              <div class="small--one-half">
                 {% if block.settings.slide_title != blank %}
                   <h3 class="featured-slider__slide-title h6" style="color: {{ section.settings.text_color }}">{{ block.settings.slide_title }}</h3>
                 {% endif %}

--- a/sections/product-recommendations.liquid
+++ b/sections/product-recommendations.liquid
@@ -9,12 +9,14 @@
         {%- comment -%}
           Large and under
         {%- endcomment -%}
-        <div class="grid grid--no-gutters grid--uniform collection-grid widescreen--hide">
+        <div class="product-recommendations__content widescreen--hide">
           {%- assign grid_item_width = 'medium--one-half large-up--one-quarter' -%}
-          {%- for product in recommendations.products -%}
-            {%- assign price = product.price | money_without_trailing_zeros -%}
-            {% include 'product-grid-item' with product_image_spacing: true, vendor_enable: section.settings.vendor_enable %}
-          {%- endfor -%}
+          <div class="product-recommendations__list">
+            {%- for product in recommendations.products -%}
+              {%- assign price = product.price | money_without_trailing_zeros -%}
+              {% include 'product-grid-item' with product_image_spacing: true, vendor_enable: section.settings.vendor_enable %}
+            {%- endfor -%}
+          </div>
         </div>
         {%- comment -%}
           Widescreen only, needs special gutters


### PR DESCRIPTION
Mobile design tweaks per Frogberg's feedback 
- new releases section: put product title + CTA side-by-side with product image
- product recommendations: allow items to overflow horizontally and scroll

<img width="667" alt="image" src="https://user-images.githubusercontent.com/6743324/163735175-fae8cdc2-21f3-4422-aaf3-be6ca9bb4267.png">
<img width="398" alt="image" src="https://user-images.githubusercontent.com/6743324/163735187-62405ca3-2e3a-4fd6-b963-6e6507cbbc49.png">
<img width="874" alt="image" src="https://user-images.githubusercontent.com/6743324/163735193-f1b70ab2-e1d1-4db2-a735-05831f7d379c.png">
